### PR TITLE
Add Grass Desktop Node

### DIFF
--- a/src/Bot.js
+++ b/src/Bot.js
@@ -49,12 +49,14 @@ class Bot {
       const ws = new WebSocket(wsURL, {
         agent,
         headers: {
-          'User-Agent': 'Mozilla/5.0',
-          pragma: 'no-cache',
-          Origin: 'chrome-extension://lkbnfiajjmbhnfledhphioinpickokdi',
+          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0',
+          'Pragma': 'no-cache',
           'Accept-Language': 'uk-UA,uk;q=0.9,en-US;q=0.8,en;q=0.7',
           'Cache-Control': 'no-cache',
-        },
+          'OS': 'Windows',
+          'Platform': 'Desktop',
+          'Browser': 'Mozilla'
+        },        
       });
 
       ws.on('open', () => {
@@ -76,9 +78,8 @@ class Bot {
               user_id: userID,
               user_agent: 'Mozilla/5.0',
               timestamp: Math.floor(Date.now() / 1000),
-              device_type: 'extension',
-              extension_id: 'lkbnfiajjmbhnfledhphioinpickokdi',
-              version: '4.26.2',
+              device_type: 'desktop',
+              version: '4.28.1',
             },
           };
           ws.send(JSON.stringify(authResponse));
@@ -118,12 +119,14 @@ class Bot {
       const wsURL = `wss://${this.config.wssHost}`;
       const ws = new WebSocket(wsURL, {
         headers: {
-          'User-Agent': 'Mozilla/5.0',
-          pragma: 'no-cache',
-          Origin: 'chrome-extension://lkbnfiajjmbhnfledhphioinpickokdi',
+          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0',
+          'Pragma': 'no-cache',
           'Accept-Language': 'uk-UA,uk;q=0.9,en-US;q=0.8,en;q=0.7',
           'Cache-Control': 'no-cache',
-        },
+          'OS': 'Windows',
+          'Platform': 'Desktop',
+          'Browser': 'Mozilla'
+        },        
       });
 
       ws.on('open', () => {
@@ -144,9 +147,8 @@ class Bot {
               user_id: userID,
               user_agent: 'Mozilla/5.0',
               timestamp: Math.floor(Date.now() / 1000),
-              device_type: 'extension',
-              extension_id: 'lkbnfiajjmbhnfledhphioinpickokdi',
-              version: '4.26.2',
+              device_type: 'desktop',
+              version: '4.28.1',
             },
           };
           ws.send(JSON.stringify(authResponse));


### PR DESCRIPTION
This update changes the headers and device type to `Desktop` for better compatibility with the Grass community node.

Key Changes:
- Updated `User-Agent` to reflect a desktop environment using Mozilla Firefox on Windows.
- Set device type to `Desktop`.
